### PR TITLE
Add new self-pace value to model and update values on appear

### DIFF
--- a/Shared/Views/SettingsView.swift
+++ b/Shared/Views/SettingsView.swift
@@ -25,7 +25,7 @@ struct SettingsView: View {
                         Text("Self-Paced Mode")
                     }
                     .onChange(of: isSelfPaced) { oldValue, newValue in
-                        plan.setSelfPaced(to: true)
+                        plan.setSelfPaced(to: newValue)
                     }
                     if (!isSelfPaced) {
                         DatePicker("Start Date", selection: $startDate, in: yearToDate, displayedComponents: [.date])
@@ -54,8 +54,10 @@ struct SettingsView: View {
             }
             .interactiveDismissDisabled(true)
             .onAppear {
-                startDate = plan.startDate
-                isSelfPaced = plan.isSelfPaced
+                DispatchQueue.main.async {
+                    startDate = plan.startDate
+                    isSelfPaced = plan.isSelfPaced
+                }
             }
             #if os(macOS)
             .frame(minHeight: 250)

--- a/The M'Cheyne Plan.xcodeproj/project.pbxproj
+++ b/The M'Cheyne Plan.xcodeproj/project.pbxproj
@@ -478,7 +478,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Shared/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Shared/Preview Content\"";
 				DEVELOPMENT_TEAM = QSQY64SHJ5;
@@ -501,7 +501,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.willswire.mcheyne-plan";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -519,7 +519,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Shared/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Shared/Preview Content\"";
 				DEVELOPMENT_TEAM = QSQY64SHJ5;
@@ -542,7 +542,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.willswire.mcheyne-plan";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;


### PR DESCRIPTION
Small fix for issue #5 

### Summary

- Ensures `plan.setSelfPaced(to:)` correctly reflects the toggle’s value instead of forcing true.
- Moves `startDate` and `isSelfPaced` updates to the main thread inside `onAppear` to prevent potential UI inconsistencies.